### PR TITLE
Use Field descriptions for settings and Pydantic Url for validation

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -11,7 +11,7 @@ icat:
 fts3:
   endpoint: https://endpoint:8446
   instrument_data_cache: root://idc:1094//
-  user_data_cache: root://udc:1094//
+  restored_data_cache: root://rdc:1094//
   tape_archive: root://archive:1094//
   x509_user_cert: hostcert.pem
   x509_user_key: hostkey.pem

--- a/datastore_api/config.py
+++ b/datastore_api/config.py
@@ -4,12 +4,21 @@ import logging
 import os
 from typing import Any
 
-from pydantic import BaseModel, BaseSettings, validator
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    BaseSettings,
+    Field,
+    parse_obj_as,
+    stricturl,
+    validator,
+)
 
 from datastore_api.utils import load_yaml
 
 
 LOGGER = logging.getLogger(__name__)
+RootUrl = stricturl(allowed_schemes={"root"})
 
 
 def yaml_config_settings_source(settings: BaseSettings) -> dict[str, Any]:
@@ -17,23 +26,64 @@ def yaml_config_settings_source(settings: BaseSettings) -> dict[str, Any]:
 
 
 class IcatUser(BaseModel):
-    auth: str
-    username: str
+    auth: str = Field(description="ICAT authentication mechanism.", example="simple")
+    username: str = Field(description="ICAT username.", example="root")
 
 
 class FunctionalUser(IcatUser):
-    password: str
+    password: str = Field(description="ICAT password.", example="pw")
 
 
 class IcatSettings(BaseModel):
-    url: str
-    check_cert: bool = True
-    admin_users: list[IcatUser] = []
-    functional_user: FunctionalUser
-    embargo_period_years: int = 2
-    parameter_type_job_ids: str = "Archival ids"
-    parameter_type_job_state: str = "Archival state"
-    embargo_types: list[str] = []
+    url: AnyHttpUrl = Field(
+        description="Url to use for the ICAT server",
+        example="https://localhost:8181",
+    )
+    check_cert: bool = Field(
+        description=(
+            "Whether the server's SSL certificate should be verified if connecting to "
+            "ICAT with HTTPS."
+        ),
+        example="https://localhost:8181",
+    )
+    admin_users: list[IcatUser] = Field(
+        default=[],
+        description=(
+            "List of ICAT users who should be allowed to perform admin actions."
+        ),
+    )
+    functional_user: FunctionalUser = Field(
+        description=(
+            "ICAT user to use when performing functional actions not associated with a "
+            "normal user, such as regular polling of the catalogue."
+        ),
+    )
+    embargo_period_years: int = Field(
+        default=2,
+        description=(
+            "Number of years to apply to the `releaseDate` if Investigations are "
+            "created without one set."
+        ),
+    )
+    parameter_type_job_ids: str = Field(
+        default="Archival ids",
+        description=(
+            "ICAT ParameterType.name to identify how to record FTS archival ids."
+        ),
+    )
+    parameter_type_job_state: str = Field(
+        default="Archival state",
+        description=(
+            "ICAT ParameterType.name to identify how to record FTS archival state."
+        ),
+    )
+    embargo_types: list[str] = Field(
+        default=[],
+        description=(
+            "List of ICAT InvestigationType.name that indicate the release date should "
+            "not be set."
+        ),
+    )
 
 
 class VerifyChecksum(StrEnum):
@@ -44,17 +94,73 @@ class VerifyChecksum(StrEnum):
 
 
 class Fts3Settings(BaseModel):
-    endpoint: str
-    instrument_data_cache: str
-    user_data_cache: str
-    tape_archive: str
-    x509_user_proxy: str = None
-    x509_user_key: str = None
-    x509_user_cert: str = None
-    retry: int = -1
-    verify_checksum: VerifyChecksum = VerifyChecksum.NONE
-    bring_online: int = 28800  # 8 hours
-    archive_timeout: int = 28800  # 8 hours
+    endpoint: AnyHttpUrl = Field(
+        description="Url to use for the FTS server",
+        example="https://localhost:8446",
+    )
+    instrument_data_cache: RootUrl = Field(
+        description="Url for the destination of raw, instrument data pre-archival",
+        example="root://localhost:1094//",
+    )
+    tape_archive: RootUrl = Field(
+        description="Url for the destination of archived data",
+        example="root://localhost:1094//",
+    )
+    restored_data_cache: RootUrl = Field(
+        description="Url for the destination of restored data post-archival",
+        example="root://localhost:1094//",
+    )
+    x509_user_proxy: str = Field(
+        default=None,
+        description=(
+            "Filepath to X509 user proxy. Not required if `x509_user_cert` and "
+            "`x509_user_key` are both set."
+        ),
+        example="/tmp/x509up_u00000",
+    )
+    x509_user_key: str = Field(
+        default=None,
+        description=(
+            "Filepath to X509 user key. Not required if `x509_user_proxy` is set."
+        ),
+        example="hostkey.pem",
+    )
+    x509_user_cert: str = Field(
+        default=None,
+        description=(
+            "Filepath to X509 user cert. Not required if `x509_user_proxy` is set."
+        ),
+        example="hostcert.pem",
+    )
+    retry: int = Field(
+        default=-1,
+        description=(
+            "Number of retries for transfers where <0 is no retries and 0 is server "
+            "default."
+        ),
+    )
+    verify_checksum: VerifyChecksum = Field(
+        default=VerifyChecksum.NONE,
+        description=(
+            "Whether to verify checksums at 'source', 'destination', 'both' or 'none'. "
+            "If 'both', then only the checksum mechanism needs to be provided with the "
+            "files and not the value."
+        ),
+    )
+    bring_online: int = Field(
+        default=28800,
+        description=(
+            "Number of seconds to wait for an archived file to be staged for "
+            "restoration. The default (28800 seconds) is 8 hours."
+        ),
+    )
+    archive_timeout: int = Field(
+        default=28800,
+        description=(
+            "Number of seconds to wait for an file to be archived. "
+            "The default (28800 seconds) is 8 hours."
+        ),
+    )
 
     @validator("x509_user_cert", always=True)
     def _validate_x509(cls, v: str, values: dict) -> str:
@@ -66,32 +172,38 @@ class Fts3Settings(BaseModel):
             x509_user_proxy = values.get("x509_user_proxy", None)
             return Fts3Settings._validate_x509_proxy(x509_user_proxy)
 
-    @validator("instrument_data_cache", "user_data_cache", "tape_archive")
-    def _validate_endpoint(cls, v: str) -> str:
-        double_slash_count = v.count("//")
-        message = f"FTS endpoint {v} did contain second '//', appending"
-        error_message = (
-            f"FTS endpoint {v} did not contain '//' twice in the form:\n"
-            "protocol://hostname//path/to/root/dir/"
-        )
-        if double_slash_count == 2:
-            if v.endswith("/"):
-                return v
-            else:
-                message = f"FTS endpoint {v} did not end with trailing '/', appending"
-                LOGGER.warn(message)
-                return f"{v}/"
-        elif double_slash_count == 1:
-            if v.endswith("//"):
-                raise ValueError(error_message)
-            elif v.endswith("/"):
-                LOGGER.warn(message)
-                return f"{v}/"
-            else:
-                LOGGER.warn(message)
-                return f"{v}//"
+    @validator("instrument_data_cache", "restored_data_cache", "tape_archive")
+    def _validate_storage_endpoint(cls, v: str) -> RootUrl:
+        url = parse_obj_as(RootUrl, v)
+        if url.query is not None:
+            raise ValueError("Url query not supported for FTS endpoint")
+        if url.fragment is not None:
+            raise ValueError("Url fragment not supported for FTS endpoint")
+
+        path = url.path
+        if path is None:
+            LOGGER.warn("FTS endpoint '%s' missing path, setting to '//'", v)
+            path = "//"
         else:
-            raise ValueError(error_message)
+            if not path.startswith("//"):
+                LOGGER.warn(
+                    "FTS endpoint '%s' path did not start with '//', appending",
+                    v,
+                )
+                path = f"/{path}"
+
+            if not path.endswith("/"):
+                LOGGER.warn("FTS endpoint '%s' path did not end with '/', appending", v)
+                path = f"{path}/"
+
+        return RootUrl.build(
+            scheme=url.scheme,
+            user=url.user,
+            password=url.password,
+            host=url.host,
+            port=url.port,
+            path=path,
+        )
 
     @staticmethod
     def _validate_x509_cert(x509_user_cert: str, x509_user_key: str | None) -> str:
@@ -121,8 +233,8 @@ class Fts3Settings(BaseModel):
 
 
 class Settings(BaseSettings):
-    icat: IcatSettings
-    fts3: Fts3Settings
+    icat: IcatSettings = Field(description="Settings to connect to an ICAT instance")
+    fts3: Fts3Settings = Field(description="Settings to connect to an FTS3 instance")
 
     class Config:
         @classmethod

--- a/datastore_api/fts3_client.py
+++ b/datastore_api/fts3_client.py
@@ -21,7 +21,7 @@ class Fts3Client:
             ukey=fts_settings.x509_user_key,
         )
         self.instrument_data_cache = fts_settings.instrument_data_cache
-        self.user_data_cache = fts_settings.user_data_cache
+        self.restored_data_cache = fts_settings.restored_data_cache
         self.tape_archive = fts_settings.tape_archive
         self.retry = fts_settings.retry
         self.verify_checksum = fts_settings.verify_checksum
@@ -38,23 +38,23 @@ class Fts3Client:
             dict[str, list]: Transfer dict for moving `path` to tape.
         """
         source = f"{self.instrument_data_cache}{path}"
-        alternate_source = f"{self.user_data_cache}{path}"
+        alternate_source = f"{self.restored_data_cache}{path}"
         destination = f"{self.tape_archive}{path}"
         transfer = fts3.new_transfer(source=source, destination=destination)
         transfer["sources"].append(alternate_source)
         return transfer
 
     def restore(self, path: str) -> dict[str, list]:
-        """Returns a transfer dict moving `path` from tape to the UDC.
+        """Returns a transfer dict moving `path` from tape to the RDC.
 
         Args:
             path (str): Path of the file to be moved.
 
         Returns:
-            dict[str, list]: Transfer dict for moving `path` to the UDC.
+            dict[str, list]: Transfer dict for moving `path` to the RDC.
         """
         source = f"{self.tape_archive}{path}"
-        destination = f"{self.user_data_cache}{path}"
+        destination = f"{self.restored_data_cache}{path}"
         return fts3.new_transfer(source=source, destination=destination)
 
     def submit(self, transfers: list[dict[str, list]], stage: bool = False) -> str:

--- a/datastore_api/transfer_controller.py
+++ b/datastore_api/transfer_controller.py
@@ -68,13 +68,13 @@ class RestoreController(TransferController):
         self.stage = True
 
     def _transfer(self, path: str) -> dict[str, list]:
-        """Returns a transfer dict moving `path` from tape to the UDC.
+        """Returns a transfer dict moving `path` from tape to the RDC.
 
         Args:
             path (str): Path of the file to be moved.
 
         Returns:
-            dict[str, list]: Transfer dict for moving `path` to the UDC.
+            dict[str, list]: Transfer dict for moving `path` to the RDC.
         """
         return self.fts3_client.restore(path)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 asyncio_mode=auto
 env =
     R:ICAT={"url": "http://127.0.0.1:18080", "check_cert": false, "functional_user": {"auth": "simple", "username": "root", "password": "pw"}, "admin_users": [{"auth": "simple", "username": "root"}], "embargo_types": ["commercial"]}
-    R:FTS3={"endpoint": "https://fts-test03.gridpp.rl.ac.uk:8446", "instrument_data_cache": "root://idc:1094//", "user_data_cache": "root://udc:1094//", "tape_archive": "root://archive:1094//", "x509_user_cert": "hostcert.pem", "x509_user_key": "hostkey.pem"}
+    R:FTS3={"endpoint": "https://fts-test03.gridpp.rl.ac.uk:8446", "instrument_data_cache": "root://idc.ac.uk:1094//", "restored_data_cache": "root://rdc.ac.uk:1094//", "tape_archive": "root://archive.ac.uk:1094//", "x509_user_cert": "hostcert.pem", "x509_user_key": "hostkey.pem"}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -55,9 +55,9 @@ def mock_fts3_settings(submit: MagicMock, mocker: MockerFixture) -> Settings:
         # pass a readable file to satisfy the validator and mock requests to FTS.
         fts3_settings = Fts3Settings(
             endpoint="https://fts-test01.gridpp.rl.ac.uk:8446",
-            instrument_data_cache="root://idc:1094//",
-            user_data_cache="root://udc:1094//",
-            tape_archive="root://archive:1094//",
+            instrument_data_cache="root://idc.ac.uk:1094//",
+            restored_data_cache="root://rdc.ac.uk:1094//",
+            tape_archive="root://archive.ac.uk:1094//",
             x509_user_cert=__file__,
             x509_user_key=__file__,
         )
@@ -88,9 +88,9 @@ def investigation_metadata(mocker: MockerFixture):
         # pass a readable file to satisfy the validator and mock requests to FTS.
         fts3_settings = Fts3Settings(
             endpoint="https://fts-test01.gridpp.rl.ac.uk:8446",
-            instrument_data_cache="root://idc:1094//",
-            user_data_cache="root://udc:1094//",
-            tape_archive="root://archive:1094//",
+            instrument_data_cache="root://idc.ac.uk:1094//",
+            restored_data_cache="root://rdc.ac.uk:1094//",
+            tape_archive="root://archive.ac.uk:1094//",
             x509_user_cert=__file__,
             x509_user_key=__file__,
         )

--- a/tests/integration/test_main_integration.py
+++ b/tests/integration/test_main_integration.py
@@ -197,8 +197,8 @@ class TestArchive:
         UUID4(content["job_ids"][0])
 
         path = "/instrument/20XX/name-visitId/type/dataset1/datafile"
-        sources = [f"root://idc:1094/{path}", f"root://udc:1094/{path}"]
-        destinations = [f"root://archive:1094/{path}"]
+        sources = [f"root://idc.ac.uk:1094/{path}", f"root://rdc.ac.uk:1094/{path}"]
+        destinations = [f"root://archive.ac.uk:1094/{path}"]
         job = fts_job(
             sources=sources,
             destinations=destinations,
@@ -299,8 +299,8 @@ class TestArchive:
         UUID4(content["job_ids"][0])
 
         path = "/instrument/20XX/name-visitId/type/dataset1/datafile"
-        sources = [f"root://idc:1094/{path}", f"root://udc:1094/{path}"]
-        destinations = [f"root://archive:1094/{path}"]
+        sources = [f"root://idc.ac.uk:1094/{path}", f"root://rdc.ac.uk:1094/{path}"]
+        destinations = [f"root://archive.ac.uk:1094/{path}"]
         job = fts_job(
             sources=sources,
             destinations=destinations,
@@ -395,8 +395,8 @@ class TestRestore:
         UUID4(content["job_ids"][0])
 
         path = "instrument/20XX/name-visitId/type/dataset/datafile"
-        sources = [f"root://archive:1094//{path}"]
-        destinations = [f"root://udc:1094//{path}"]
+        sources = [f"root://archive.ac.uk:1094//{path}"]
+        destinations = [f"root://rdc.ac.uk:1094//{path}"]
         job = fts_job(
             sources=sources,
             destinations=destinations,

--- a/tests/unit/models/test_archive.py
+++ b/tests/unit/models/test_archive.py
@@ -76,10 +76,10 @@ class TestArchive:
         # pass a readable file to satisfy the validator.
         get_settings_mock = mocker.patch("datastore_api.models.archive.get_settings")
         fts3_settings = Fts3Settings(
-            endpoint="",
-            instrument_data_cache="root://idc:1094//",
-            user_data_cache="root://udc:1094//",
-            tape_archive="root://archive:1094//",
+            endpoint="https://localhost:8446",
+            instrument_data_cache="root://idc.ac.uk:1094//",
+            restored_data_cache="root://rdc.ac.uk:1094//",
+            tape_archive="root://archive.ac.uk:1094//",
             x509_user_cert=__file__,
             x509_user_key=__file__,
         )


### PR DESCRIPTION
- Use `Field` with `description` for all settings fields to document the meaning of them.
- Rename "user data cache" to "restored data cache" as changes to the architecture plan mean the term user data cache will now be used for users home folders but not restored data, so need to distinguish them properly
- Use Pydantic's Urls for appropriate fields, and change the FTS storage endpoint validators to use this
- Update the various urls used for tests and mocks to be actual urls to pass the stricter validation, e.g.:
  - No empty strings
  - Host needs a top level domain
  - Port should actually be a number

Does not close #46 as the proposed tool is only compatible for a more recent version of Pydantic. Updating that should be a separate issue, after which #46 can be revisited. The documentation in the code is still an improvement in the meantime.

Closes #48 