### PR TITLE
cherry-pick Dockerfile changes onto updated main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .venv/
 venv/
 .idea/
+.tmp/
 *.pyc
 *.log
 *.log.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+# Add Poetry to PATH
+ENV PATH="/root/.local/bin:$PATH"
+
+ARG ENVIRONMENT="PROD"
+RUN echo "ENVIRONMENT value is ${ENVIRONMENT}"
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install system dependencies for building M2Crypto and install Poetry
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libssl-dev \
+    swig \
+    curl \
+    && curl -sSL https://install.python-poetry.org | python3 - \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+
+# Copy the project files to the container and install
+COPY pyproject.toml poetry.lock config.yaml.example logging.ini.example /app/
+RUN if [ ${ENVIRONMENT} = "PROD" ]; then \
+        echo "Installing DEVELOPMENT dependencies" && \
+        poetry install --without=dev; \
+    elif [ ${ENVIRONMENT} = "DEV" ]; then \
+        echo "Installing DEVELOPMENT dependencies" && \
+        touch hostkey.pem && \
+        touch hostcert.pem && \
+        cp config.yaml.example config.yaml && \
+        cp logging.ini.example logging.ini && \
+        poetry install --with=dev; \
+    else \
+        echo "ENVIRONMENT must be one of DEV, PROD" && \
+        exit 1; \
+    fi
+
+# Copy the rest of the application code
+COPY . /app
+
+# Expose the port the app will run on
+EXPOSE 8000
+
+# Run FastAPI server
+CMD ["poetry","run","uvicorn", "--host=0.0.0.0", "--port=8000", "--log-config=logging.ini", "--reload", "datastore_api.main:app"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To develop the API Python development tools will need to be installed. The exact
 sudo yum install "@Development Tools" python3.11-devel python3.11 python3.11-setuptools openldap-devel swig gcc openssl-devel xrootd-client
 ```
 
-Before running the API, create the `config.yaml` and `logging.ini` config files. A sample configuration can be copied from the `config.yaml.example` and `logging.ini.example` files.
+Configuration is handled via the `config.yaml` and `logging.ini` config files.
 
 ### Poetry
 [Poetry](https://python-poetry.org/) is used to manage the dependencies of this API. Note that to prevent conflicts Poetry should not be installed in the environment used for the project dependencies; [different recommended installation methods are possible](https://python-poetry.org/docs/#installing-with-the-official-installer). _(Note that pipx may not install the latest version)_
@@ -85,7 +85,7 @@ icatingest.py -i datastore_api/scripts/example.yaml -f YAML --duplicate IGNORE -
 
 If desired the entities in `example.yaml` can be modified or extended following the [python-icat documentation](https://python-icat.readthedocs.io/en/1.3.0/icatingest.html). There are other files which will create multiple entities, if needed.
 
-To verify that the entities are created correctly, the usual methods of inspecting the database (either by the command line within its container or via DB inspection software) or running commands against ICAT (via curl or a full stack including frontend) are possible, however for these use cases the [ICAT admin](https://vigorous-lamarr-7b3487.netlify.app/) web app offers a simple and quick method of verifying the entities are created. The full address and port (e.g. http://localhost:18080 if using Docker to forward the container port to the host machine as described above) is needed along with the credentials used in the tests:
+To verify that the entities are created correctly, the usual methods of inspecting the database (either by the command line within its container or via DB inspection software) or running commands against ICAT (via curl or a full stack including frontend) are possible, however for these use cases the [ICAT admin](https://icatadmin.netlify.app/) web app offers a simple and quick method of verifying the entities are created. The full address and port (e.g. http://localhost:18080 if using Docker to forward the container port to the host machine as described above) is needed along with the credentials used in the tests:
 ```yaml
 auth: simple
 username: root

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,5 +1,5 @@
 icat:
-  url: https://127.0.0.1:8181
+  url: https://icat_payara_container:8181
   check_cert: False
   functional_user:
     auth: simple
@@ -10,14 +10,14 @@ icat:
       username: root
 
 fts3:
-  endpoint: https://endpoint:8446
-  instrument_data_cache: root://idc:1094//
-  restored_data_cache: root://rdc:1094//
-  tape_archive: root://archive:1094//
+  endpoint: https://lcgfts3.gridpp.rl.ac.uk:8446
+  instrument_data_cache: root://idc.ac.uk:1094//
+  restored_data_cache: root://rdc.ac.uk:1094//
+  tape_archive: root://archive.ac.uk:1094//
   x509_user_cert: hostcert.pem
   x509_user_key: hostkey.pem
 
 s3:
-  endpoint: http://127.0.0.1:9000
+  endpoint: http://minio:9000
   access_key: minioadmin
   secret_key: minioadmin

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ asyncio_mode=auto
 env =
     R:ICAT={"url": "http://127.0.0.1:18080", "check_cert": false, "functional_user": {"auth": "simple", "username": "root", "password": "pw"}, "admin_users": [{"auth": "simple", "username": "root"}], "embargo_types": ["commercial"]}
     R:S3={"endpoint": "http://127.0.0.1:9000", "access_key": "minioadmin", "secret_key": "minioadmin" }
-    R:FTS3={"endpoint": "https://fts-test02.gridpp.rl.ac.uk:8446", "instrument_data_cache": "root://idc.ac.uk:1094//", "restored_data_cache": "root://rdc.ac.uk:1094//", "tape_archive": "root://archive.ac.uk:1094//", "x509_user_cert": "hostcert.pem", "x509_user_key": "hostkey.pem"}
+    R:FTS3={"endpoint": "https://lcgfts3.gridpp.rl.ac.uk:8446", "instrument_data_cache": "root://idc.ac.uk:1094//", "restored_data_cache": "root://rdc.ac.uk:1094//", "tape_archive": "root://archive.ac.uk:1094//", "x509_user_cert": "hostcert.pem", "x509_user_key": "hostkey.pem"}

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
 
   # Database needed to store the test data
@@ -20,12 +18,12 @@ services:
       MARIADB_PASSWORD: icatdbuserpw
     # the health check will tell us when data is in the DB
     healthcheck:
-      test: "/usr/bin/mysql --user=$$MARIADB_USER --password=$$MARIADB_PASSWORD --execute \"SHOW TABLES;\""
+      test: "/usr/bin/mysql --database=$$MARIADB_DATABASE --user=$$MARIADB_USER --password=$$MARIADB_PASSWORD --execute \"SHOW TABLES;\""
       interval: 10s
       timeout: 2s
       retries: 10
     networks:
-      - network
+      - datastore_network
 
   # The ICAT server, available at https://localhost:18181/icat/version
   icat_payara:
@@ -33,7 +31,8 @@ services:
     image: harbor.stfc.ac.uk/icat/icat_5:latest
     container_name: icat_payara_container
     depends_on:
-      - icat_mariadb
+      icat_mariadb:
+        condition: service_healthy
     ports:
       - "14747:4848" # payara port
       - "18181:8181" # https port
@@ -50,7 +49,7 @@ services:
       timeout: 2s
       retries: 10
     networks:
-      - network
+      - datastore_network
 
   # The Auth service needed by ICAT, available at https://localhost:28181/authn.simple/version/
   auth_payara:
@@ -61,7 +60,7 @@ services:
       - "24747:4848"
       - "28181:8181"
     networks:
-      - network
+      - datastore_network
 
   # The minio instance that simulates s3 buckets for download functionality
   # UI available at http://localhost:9000
@@ -83,7 +82,7 @@ services:
       timeout: 2s
       retries: 10
     networks:
-      network:
+      - datastore_network
 
   # Script that inits minio with a bucket and an object
   mc:
@@ -104,7 +103,31 @@ services:
       exit 0;
       "
     networks:
-      - network
+      - datastore_network
+
+  datastore-api:
+    build:
+      context: ../.
+      args:
+        - ENVIRONMENT=DEV
+    ports:
+      - "8000:8000"
+    depends_on:
+      icat_payara:
+        condition: service_healthy
+    networks:
+      - datastore_network
+    profiles: [full]
+
+  testdata:
+    image: harbor.stfc.ac.uk/icat/icat_testdata:latest
+    container_name: testdata_container
+    depends_on:
+      icat_payara:
+        condition: service_healthy
+    networks:
+      - datastore_network
+    profiles: [full]
 
 volumes:
   minio_data:
@@ -114,4 +137,4 @@ volumes:
 # derived from the directory name. In this case test_doi_test_network.
 # docker run --network=tests_doi_test_network doi-mint-api pytest -c tests/pytest.ini
 networks:
-  network:
+  datastore_network:


### PR DESCRIPTION
As I mentioned in the issue, the changes to the Pydantic version from #61 and to the `docker-compose.yaml` conflicted with some of the changes on [63_dockerfile](https://github.com/ral-facilities/datastore-api/tree/63_dockerfile), so cherrypicked/resolved and made some further changes to get it working for me.

- `.gitignore`: unrelated, my container was taking ages to build because I had a 10GB file for testing the transfer load that was just sitting in the project root directory, so moved it to a hidden folder to avoid it getting picked up by `COPY . /app` and put it on the `.gitignore` for good measure so I don't accidentally commit it...
- `Dockerfile`: the change I made is to add the `PROD`/`DEV` argument so that we can create something that passes validation by copying the `.example` configs only when in `DEV`. My assumption is that for production, you would mount these files directly? Because this happens before `COPY . /app`, if you do have real configs locally they will still be used and overwrite the placeholders. The main thing I'm trying to avoid is that if we include a `config.yaml` in the repo with example values:
  - Every time I check out it will overwrite my local settings. Because `config.yaml` and `logging.ini` are in the `.gitignore` it will not check for conflicts and just wipe them. This did actually happen to me when I checkout out your branch, but luckily I'd copied my `config.yaml` before as a precaution.
  - Even if it were removed from the `.gitignore`, you would have to stash your local config on checkout to avoid conflicts and there's then the risk that I publish my local settings by mistake, as well as it being hard to update the "example" config when a new option is added (as I'd need to juggle my local config and the example config).
  - Regarding the `hostcert.pem`/`hostkey.pem`, I've created two empty files for `DEV`. This will let the API start, but it will still fail whenever you try and run anything against FTS (e.g. you can login and get an ICAT sessionId but any transfer requests will fail) - ultimately I don't think there's anything we can do here (excluding some effort to get FTS running in a container but I think that's a separate issue and would need to involve Tom Byrne etc.) as there is no default/example/dummy cert - it's either real or it's nothing.
- `config.yaml.example`: like I said I felt we needed to keep this, but I updated these to use the same values as the `pytest.ini`. These should have been in sync anyway. The values in there for the URLs etc. should work as the tests need to get past validation. The change to Pydantic 2 might also have affected the details of the validation.
- `docker-compose.yaml` Added `testdata` and put it on a new profile along with the datastore-api. The `testdata` container still failed for me as I think it makes a lot of assumptions (e.g. hardcoded entity ids) and I might have not been using a fresh built DB. But it ran at least.

As far as I can recall I think this meets all the needs we had. Using the `full` profile and both with/without my local config, I was able to run the API. But if any of the changes I've made aren't compatible with how you're planning on containerising the whole service let me know.

Closes #63 