### PR TITLE
Add optional pre-transfer source checks #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ logging.ini*
 util/realistic_data/data
 util/realistic_data/resources
 *.pem
+.tmp/
+*.whl

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Changing the optional arguments as needed. Documentation can be found by navigat
 To develop the API Python development tools will need to be installed. The exact command will vary, for example on Rocky 8:
 
 ```bash
-sudo yum install "@Development Tools" python3.11-devel python3.11 python3.11-setuptools openldap-devel swig gcc openssl-devel xrootd-client
+sudo yum install "@Development Tools" python3.11-devel python3.11 python3.11-setuptools openldap-devel swig gcc openssl-devel xrootd-client cmake3 libuv-1:1.41.1 libuuid-devel
 ```
 
 Before running the API, create the `config.yaml` and `logging.ini` config files. A sample configuration can be copied from the `config.yaml.example` and `logging.ini.example` files.

--- a/datastore_api/clients/x_root_d_client.py
+++ b/datastore_api/clients/x_root_d_client.py
@@ -1,0 +1,71 @@
+from functools import lru_cache
+
+from fastapi import HTTPException
+from pydantic_core import Url
+from XRootD import client
+from XRootD.client.responses import StatInfo
+
+
+class XRootDClient:
+    """Wrapper for XRootD functionality."""
+
+    def __init__(self, url: str) -> None:
+        """Initialise the client for specific XRootD server.
+
+        Args:
+            url (str): Unformatted url for connecting to an XRootD server.
+        """
+        url_object = Url(url)
+        self.url_path = url_object.path.replace("//", "/")
+        root_url = self._validate_url(url_object)
+
+        self.client = client.FileSystem(url=root_url)
+
+    @staticmethod
+    def _validate_url(url_object: Url) -> str:
+        """Validates url to ensure it uses the root protocol and port.
+
+        Args:
+            url_object (Url): Unvalidated Pydantic Url Object.
+
+        Returns:
+            str: Validated url as a str, with the root protocol.
+        """
+        if url_object.scheme != "root":
+            root_url = Url.build(
+                scheme="root",
+                host=url_object.host,
+                port=1094,
+            )
+        else:
+            root_url = Url.build(
+                scheme=url_object.scheme,
+                host=url_object.host,
+                port=url_object.port,
+            )
+
+        return str(root_url)
+
+    def stat(self, location: str) -> StatInfo:
+        """Stat a file on this XRootD server.
+
+        Args:
+            location (str): ICAT Datafile.location for a single object.
+
+        Raises:
+            HTTPException: If file is not found in the XRootD server.
+
+        Returns:
+            StatInfo: Stat info of the requested file.
+        """
+        stat_info = self.client.stat(path=f"{self.url_path}{location}")
+        status = stat_info[0]
+        if status.code != 0:
+            raise HTTPException(status_code=status.code, detail=status.message)
+
+        return stat_info[1]
+
+
+@lru_cache
+def get_x_root_d_client(url: str) -> XRootDClient:
+    return XRootDClient(url=url)

--- a/datastore_api/config.py
+++ b/datastore_api/config.py
@@ -260,6 +260,28 @@ class Fts3Settings(BaseModel):
         default=[],
         description="List of possible storage endpoints FTS can transfer between.",
     )
+    check_source: bool = Field(
+        default=False,
+        description=(
+            "Check the existence of the source file before submitted to FTS. "
+            "If set and source file not found, will raise an error. "
+            "If set, will also use the returned file size for checking against limits."
+        ),
+    )
+    file_size_limit: int = Field(
+        default=None,
+        description=(
+            "If set, will raise an error if an individual file is submitted which "
+            "exceeds this size."
+        ),
+    )
+    total_file_size_limit: int = Field(
+        default=None,
+        description=(
+            "If set, will raise an error if the total size of a request exceeds this "
+            "size."
+        ),
+    )
 
     @staticmethod
     def _validate_x509_file(setting: str, x509_file: str) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2030,7 +2030,17 @@ h11 = ">=0.8"
 [package.extras]
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
+[[package]]
+name = "xrootd"
+version = "5.7.1"
+description = "eXtended ROOT daemon"
+optional = false
+python-versions = "*"
+files = [
+    {file = "xrootd-5.7.1.tar.gz", hash = "sha256:dac741afefdb459b675cf3c61523324d11200c5825b532416bfa67444de5d4a2"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "767c38c1842d6af7140b832e75eb8668f48e116fea875288d467da8c895ac97d"
+content-hash = "df0cddce50ddf270c4ffc0b1ee8d4e66a5fefdbd7c582c8d83a4c3743872e7e9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ annotated-types = "^0.6.0"
 boto3 = "^1.34.127"
 pydantic-settings = "^2.4.0"
 mypy-boto3-s3 = "^1.35.46"
+xrootd = "^5.7.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.3.0"

--- a/tests/unit/clients/test_x_root_d_client.py
+++ b/tests/unit/clients/test_x_root_d_client.py
@@ -1,0 +1,23 @@
+from pydantic_core import Url
+import pytest
+
+from datastore_api.clients.x_root_d_client import XRootDClient
+
+
+class TestXRootDClient:
+    @pytest.mark.parametrize(
+        ["url", "expected_path"],
+        [
+            pytest.param("https://localhost:1095/", "/"),
+            pytest.param("https://localhost:1095/path/", "/path/"),
+            pytest.param("root://localhost:1094//", "/"),
+            pytest.param("root://localhost:1094//path/", "/path/"),
+        ],
+    )
+    def test_init(self, url: str, expected_path: str):
+        x_root_d_client = XRootDClient(url=url)
+        assert x_root_d_client.url_path == expected_path
+
+    def test_validate_url(self):
+        url = XRootDClient._validate_url(Url("https://localhost:1095/path"))
+        assert url == "root://localhost:1094"

--- a/tests/unit/controllers/test_investigation_archiver.py
+++ b/tests/unit/controllers/test_investigation_archiver.py
@@ -1,3 +1,5 @@
+from fts3.rest.client.exceptions import ServerError
+import pytest
 from pytest_mock import mocker, MockerFixture
 
 from datastore_api.clients.icat_client import get_icat_cache, IcatCache, IcatClient
@@ -23,6 +25,7 @@ from tests.fixtures import (
 
 
 class TestInvestigationArchiver:
+    @pytest.mark.flaky(only_on=[ServerError])
     def test_investigation_archiver(
         self,
         mock_fts3_settings: Settings,

--- a/tests/unit/controllers/test_transfer_controller.py
+++ b/tests/unit/controllers/test_transfer_controller.py
@@ -1,9 +1,31 @@
 from fastapi import HTTPException
+from icat.entity import Entity
 import pytest
+from pytest_mock import MockerFixture
 
-from datastore_api.controllers.transfer_controller import DatasetReArchiver
+from datastore_api.clients.x_root_d_client import get_x_root_d_client
+from datastore_api.config import get_settings, Settings
+from datastore_api.controllers.transfer_controller import (
+    DatasetReArchiver,
+    TransferController,
+)
 from datastore_api.models.dataset import DatasetStatusListFilesResponse
 from datastore_api.models.job import JobState
+from tests.fixtures import (
+    cache_bucket,
+    datafile_failed,
+    dataset_failed,
+    dataset_type,
+    facility,
+    facility_cycle,
+    functional_icat_client,
+    instrument,
+    investigation,
+    investigation_type,
+    mock_fts3_settings,
+    parameter_type_state,
+    submit,
+)
 
 
 class TestDatasetReArchiver:
@@ -28,3 +50,140 @@ class TestDatasetReArchiver:
             DatasetReArchiver._validate_status(status)
 
         assert e.exconly() == error
+
+
+class TestTransferController:
+    def test_check_source_s3(
+        self,
+        datafile_failed: Entity,
+        cache_bucket: str,
+        mocker: MockerFixture,
+    ):
+        datafile_failed.location = "test"
+        transfer_controller = TransferController(
+            datafile_entities=[datafile_failed],
+            source_key="echo",
+            destination_key="rdc",
+        )
+        transfer_controller.fts3_client.fts3_settings.check_source = True
+
+        transfer_controller._check_source(transfer_controller.datafile_entities[0])
+
+        assert transfer_controller.datafile_entities[0].fileSize == 4
+
+    def test_check_source_s3_failure(
+        self,
+        mock_fts3_settings: Settings,
+        datafile_failed: Entity,
+        cache_bucket: str,
+        mocker: MockerFixture,
+    ):
+        settings_copy = mock_fts3_settings.fts3.model_copy()
+        settings_copy.check_source = True
+        datafile_failed.location = "testtest"
+        transfer_controller = TransferController(
+            datafile_entities=[datafile_failed],
+            source_key="echo",
+            destination_key="rdc",
+        )
+        transfer_controller.fts3_client.fts3_settings = settings_copy
+
+        with pytest.raises(HTTPException) as e:
+            transfer_controller._check_source(transfer_controller.datafile_entities[0])
+
+        assert e.exconly() == (
+            "fastapi.exceptions.HTTPException: 404: "
+            "File not found at cache-bucket/testtest"
+        )
+
+    def test_check_source_x_root_d(
+        self,
+        mock_fts3_settings: Settings,
+        datafile_failed: Entity,
+        mocker: MockerFixture,
+    ):
+        get_x_root_d_client.cache_clear()
+        settings_copy = mock_fts3_settings.fts3.model_copy()
+        settings_copy.check_source = True
+        datafile_failed.location = "test"
+        transfer_controller = TransferController(
+            datafile_entities=[datafile_failed],
+            source_key="idc",
+            destination_key="rdc",
+        )
+        transfer_controller.fts3_client.fts3_settings = settings_copy
+        mocked_status = mocker.MagicMock()
+        mocked_status.code = 0
+        mocked_stat_info = mocker.MagicMock()
+        mocked_stat_info.size = 4
+        mocked_client = mocker.MagicMock()
+        mocked_client.stat.return_value = [mocked_status, mocked_stat_info]
+        mocked_file_system = mocker.MagicMock()
+        mocked_file_system.return_value = mocked_client
+        module = "datastore_api.clients.x_root_d_client.client.FileSystem"
+        mocker.patch(module, mocked_file_system)
+
+        transfer_controller._check_source(transfer_controller.datafile_entities[0])
+
+        assert transfer_controller.datafile_entities[0].fileSize == 4
+
+    def test_check_source_x_root_d_failure(
+        self,
+        mock_fts3_settings: Settings,
+        datafile_failed: Entity,
+        mocker: MockerFixture,
+    ):
+        get_x_root_d_client.cache_clear()
+        settings_copy = mock_fts3_settings.fts3.model_copy()
+        settings_copy.check_source = True
+        datafile_failed.location = "test"
+        transfer_controller = TransferController(
+            datafile_entities=[datafile_failed],
+            source_key="idc",
+            destination_key="rdc",
+        )
+        transfer_controller.fts3_client.fts3_settings = settings_copy
+        mocked_status = mocker.MagicMock()
+        mocked_status.code = 400
+        mocked_status.message = "[3005] Unable to open directory"
+        mocked_client = mocker.MagicMock()
+        mocked_client.stat.return_value = [mocked_status]
+        mocked_file_system = mocker.MagicMock()
+        mocked_file_system.return_value = mocked_client
+        module = "datastore_api.clients.x_root_d_client.client.FileSystem"
+        mocker.patch(module, mocked_file_system)
+
+        with pytest.raises(HTTPException) as e:
+            transfer_controller._check_source(transfer_controller.datafile_entities[0])
+
+        assert e.exconly() == (
+            "fastapi.exceptions.HTTPException: 400: [3005] Unable to open directory"
+        )
+
+    def test_validate_file_size(self, mock_fts3_settings: Settings):
+        settings_copy = mock_fts3_settings.fts3.model_copy()
+        settings_copy.file_size_limit = 1
+        transfer_controller = TransferController([])
+        transfer_controller.fts3_client.fts3_settings = settings_copy
+        with pytest.raises(HTTPException) as e:
+            transfer_controller._validate_file_size(2)
+
+        assert e.exconly() == (
+            "fastapi.exceptions.HTTPException: 400: "
+            "Cannot accept file of size 2 due to limit of 1"
+        )
+        assert transfer_controller.total_size == 2
+
+    def test_validate_total_size(self, mock_fts3_settings: Settings):
+        settings_copy = mock_fts3_settings.fts3.model_copy()
+        settings_copy.total_file_size_limit = 1
+        transfer_controller = TransferController([])
+        transfer_controller.fts3_client.fts3_settings = settings_copy
+        transfer_controller.total_size = 2
+        with pytest.raises(HTTPException) as e:
+            transfer_controller._validate_total_size()
+
+        assert e.exconly() == (
+            "fastapi.exceptions.HTTPException: 400: "
+            "Cannot accept transfer request of total size 2 due to limit of 1"
+        )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -25,6 +25,7 @@ from tests.fixtures import (
 @pytest.fixture(scope="function")
 def test_client(mock_fts3_settings: Settings, mocker: MockerFixture):
     datafile = mocker.MagicMock(name="datafile")
+    datafile.fileSize = None
     dataset = mocker.MagicMock(name="dataset")
     dataset_parameter_state = mocker.MagicMock(name="dataset_parameter_state")
     dataset_parameter_state.type.name = "Archival state"
@@ -84,8 +85,8 @@ class TestMain:
             json=json_body,
         )
 
+        assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
-        assert test_response.status_code == 200, content
         assert "dataset_ids" in content
         assert content["dataset_ids"] == [1]
         assert "job_ids" in content
@@ -102,8 +103,8 @@ class TestMain:
             json=json_body,
         )
 
+        assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
-        assert test_response.status_code == 200, content
         assert "job_ids" in content
         assert len(content["job_ids"]) == 1
         UUID(content["job_ids"][0], version=4)
@@ -126,39 +127,39 @@ class TestMain:
             headers=headers,
         )
 
+        assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
-        assert test_response.status_code == 200, content
         assert content == {"state": "FINISHED"}
 
     def test_status(self, test_client: TestClient):
         headers = {"Authorization": f"Bearer {SESSION_ID}"}
         test_response = test_client.get("/job/1/status", headers=headers)
 
+        assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
-        assert test_response.status_code == 200, content
         assert content == {"status": STATUSES[0]}
 
     def test_complete(self, test_client: TestClient):
         headers = {"Authorization": f"Bearer {SESSION_ID}"}
         test_response = test_client.get("/job/1/complete", headers=headers)
 
+        assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
-        assert test_response.status_code == 200, content
         assert content == {"complete": True}
 
     def test_percentage(self, test_client: TestClient):
         headers = {"Authorization": f"Bearer {SESSION_ID}"}
         test_response = test_client.get("/job/1/percentage", headers=headers)
+        assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
-        assert test_response.status_code == 200, content
         assert content == {"percentage_complete": 100.0}
 
     def test_cancel(self, test_client: TestClient):
         headers = {"Authorization": f"Bearer {SESSION_ID}"}
         test_response = test_client.delete("/job/1", headers=headers)
 
+        assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
-        assert test_response.status_code == 200, content
         assert content == {"state": "CANCELED"}
 
     def test_version(self, test_client: TestClient):


### PR DESCRIPTION
- Update `.ignore` for files generated when trying to install the xrootd python bindings
- Add packages needed to install xrootd python bindings to README and as a dependency in pyproject.toml
- Add `stat` functions to the S3 and XRootD storage clients for checking the existence and size of files
- Add config options to check the existence of source files and/or limit the size of files/requests
- Slightly refactor the `_submit` logic to allow us to block based on total size before submitting anything
- Tests for new functionality

#41