### PR TITLE
Use union of types for dataset status return type

### DIFF
--- a/datastore_api/controllers/state_controller.py
+++ b/datastore_api/controllers/state_controller.py
@@ -404,7 +404,7 @@ class StateController:
         self,
         dataset_id: int,
         list_files: bool = False,
-    ) -> DatasetStatusResponse:
+    ) -> DatasetStatusListFilesResponse | DatasetStatusResponse:
         """Get the status of a Dataset that may or may not have completed archival.
 
         Args:
@@ -431,7 +431,7 @@ class StateController:
         self,
         parameters: list[Entity],
         list_files: bool,
-    ) -> DatasetStatusResponse:
+    ) -> DatasetStatusListFilesResponse | DatasetStatusResponse:
         """Get and update the status of a Dataset using the latest FTS information.
 
         Args:
@@ -456,7 +456,7 @@ class StateController:
         self,
         dataset_id: int,
         list_files: bool,
-    ) -> DatasetStatusResponse:
+    ) -> DatasetStatusListFilesResponse | DatasetStatusResponse:
         """Get the status of a Dataset with completed archival.
 
         Args:

--- a/datastore_api/main.py
+++ b/datastore_api/main.py
@@ -489,7 +489,7 @@ def dataset_status(
     session_id: SessionIdDependency,
     dataset_id: str,
     list_files: bool = True,
-) -> DatasetStatusResponse:
+) -> DatasetStatusListFilesResponse | DatasetStatusResponse:
     """Get details of a previously archived Dataset
     \f
     Args:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,7 +8,10 @@ from pytest_mock import mocker, MockerFixture
 from datastore_api.config import Settings
 from datastore_api.main import app
 from datastore_api.models.archive import ArchiveRequest
-from datastore_api.models.dataset import DatasetStatusListFilesResponse, DatasetStatusResponse
+from datastore_api.models.dataset import (
+    DatasetStatusListFilesResponse,
+    DatasetStatusResponse,
+)
 from datastore_api.models.job import TransferState
 from datastore_api.models.transfer import TransferRequest
 from tests.fixtures import (

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,7 +8,8 @@ from pytest_mock import mocker, MockerFixture
 from datastore_api.config import Settings
 from datastore_api.main import app
 from datastore_api.models.archive import ArchiveRequest
-from datastore_api.models.dataset import DatasetStatusResponse
+from datastore_api.models.dataset import DatasetStatusListFilesResponse, DatasetStatusResponse
+from datastore_api.models.job import TransferState
 from datastore_api.models.transfer import TransferRequest
 from tests.fixtures import (
     archive_request,
@@ -117,7 +118,6 @@ class TestMain:
         response = DatasetStatusResponse(state="FINISHED")
         state_controller_mock = mocker.patch("datastore_api.main.StateController")
         state_controller = state_controller_mock.return_value
-        state_controller.get_dataset_job_ids.return_value = []
         state_controller.get_dataset_status.return_value = response
 
         headers = {"Authorization": f"Bearer {SESSION_ID}"}
@@ -130,6 +130,30 @@ class TestMain:
         assert test_response.status_code == 200, test_response.content
         content = json.loads(test_response.content)
         assert content == {"state": "FINISHED"}
+
+    def test_get_dataset_list_files(
+        self,
+        test_client: TestClient,
+        mocker: MockerFixture,
+    ):
+        response = DatasetStatusListFilesResponse(
+            state="FINISHED",
+            file_states={"test": TransferState.finished},
+        )
+        state_controller_mock = mocker.patch("datastore_api.main.StateController")
+        state_controller = state_controller_mock.return_value
+        state_controller.get_dataset_status.return_value = response
+
+        headers = {"Authorization": f"Bearer {SESSION_ID}"}
+        test_response = test_client.get(
+            "/dataset/1/status",
+            params={"list_files": True},
+            headers=headers,
+        )
+
+        assert test_response.status_code == 200, test_response.content
+        content = json.loads(test_response.content)
+        assert content == {"state": "FINISHED", "file_states": {"test": "FINISHED"}}
 
     def test_status(self, test_client: TestClient):
         headers = {"Authorization": f"Bearer {SESSION_ID}"}


### PR DESCRIPTION
Prior to this fix, the return type in main was causing us to cast the response to the more restrictive `DatasetStatusResponse` even when `list_files` was `True`, meaning the list of file states was never returned. By using a union with the subclass `DatasetStatusListFilesResponse` first, FastAPI will cast to this if possible meaning we get the list of files when appropriate.

Added test alongside existing one in `test_main.py`

Closes #87 